### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/frizzle-chan/mudd/security/code-scanning/3](https://github.com/frizzle-chan/mudd/security/code-scanning/3)

In general, this problem is fixed by explicitly adding a `permissions:` section in the workflow (either at the top level, applying to all jobs, or within the specific job) to restrict the `GITHUB_TOKEN` to the minimum scopes needed. For a simple CI pipeline that just checks out code and runs tests or linters, it’s typically sufficient to grant only `contents: read`, or even `permissions: read-all` if no writes are required.

For this workflow, the `verify` job only checks out code and runs Python tooling; it does not perform any write operations to the repository, issues, or pull requests. Therefore, the best change that preserves existing functionality while improving security is to set permissions at the workflow level to `contents: read`. This follows CodeQL’s suggested minimal starting point and still allows `actions/checkout` to function. Concretely, in `.github/workflows/ci.yaml`, add a top-level `permissions:` block after the `name: CI` line (before `on:`). No additional imports or methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
