### PR TITLE
Add dev environment improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,3 +47,13 @@ Pre-commit hooks (lefthook) auto-run ruff and ty on staged files.
 - `ruff` - Linting and formatting
 - `ty` - Type checking (Astral)
 - `uv` - Package management
+
+## Devcontainer Setup
+
+If you encounter permission issues pushing to GitHub, run:
+
+```bash
+just devcontainer
+```
+
+This authenticates the GitHub CLI using the token in `.github-token.txt`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,9 +57,11 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
        curl \
        git \
+       jq \
        just \
        procps \
        redis-server \
+       ripgrep \
        vim \
        zsh \
  && apt-get install -y --no-install-recommends -t trixie-backports \


### PR DESCRIPTION
## Summary

- Add useful development tools to devcontainer: `jq` and `ripgrep`
- Document `just devcontainer` command for GitHub CLI authentication

## Changes

- `Dockerfile`: Add `jq` and `ripgrep` packages to devcontainer stage
- `CLAUDE.md`: Add "Devcontainer Setup" section explaining GitHub auth

## Test plan

- [ ] Verify devcontainer builds successfully
- [ ] Confirm `jq` and `rg` commands are available in container
- [ ] Test `just devcontainer` runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)