### PR TITLE
Fix PostgreSQL migration cleanup: add migrations to Docker, update docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 
 !main.py
 !mudd/
+!migrations/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,13 +37,15 @@ Pre-commit hooks (lefthook) auto-run ruff and ty on staged files.
 
 **MUD concept**: Channel topics = room descriptions. Movement hides/shows channels via Discord permissions.
 
-**Design docs**: See `DESIGN.md` for Redis schema and data persistence details. **Always update DESIGN.md when modifying the Redis schema.**
+**Design docs**: See `DESIGN.md` for PostgreSQL schema and data persistence details. **Always update DESIGN.md when modifying the database schema.**
+
+**Docker**: The `.dockerignore` uses an allowlist pattern (starts with `*`, then `!` to include specific paths). **When adding new top-level directories needed at runtime, you must add them to `.dockerignore`.**
 
 ## Dependencies
 
 - `discord.py` - Discord bot library
 - `python-dotenv` - Environment variable loading
-- `redis` - Redis client for location persistence
+- `asyncpg` - PostgreSQL client for data persistence
 - `ruff` - Linting and formatting
 - `ty` - Type checking (Astral)
 - `uv` - Package management

--- a/docs/adr/CLAUDE.md
+++ b/docs/adr/CLAUDE.md
@@ -34,4 +34,4 @@ Each decision should follow this format:
 
 Example:
 
-> In the context of **runtime entity access**, facing **the need for fast lookups during gameplay**, we decided to **store entity data in Redis**, to achieve **low-latency access**, accepting **Redis as a runtime dependency**.
+> In the context of **runtime entity access**, facing **the need for fast lookups during gameplay**, we decided to **store entity data in PostgreSQL**, to achieve **persistent storage with reliable queries**, accepting **PostgreSQL as a runtime dependency**.

--- a/mudd/cogs/movement.py
+++ b/mudd/cogs/movement.py
@@ -148,7 +148,7 @@ class Movement(commands.Cog):
 
     @commands.Cog.listener()
     async def on_member_remove(self, member: discord.Member):
-        """Clean up Redis when member leaves."""
+        """Clean up user location when member leaves."""
         try:
             service = get_visibility_service()
             await service.delete_user_location(member.id)


### PR DESCRIPTION
## Summary
- Add `migrations/` to `.dockerignore` allowlist (was missing from Docker image after PostgreSQL migration)
- Update `CLAUDE.md`: change Redis references to PostgreSQL, add note about `.dockerignore` allowlist pattern to prevent this bug in future reviews
- Fix stale "Clean up Redis" comment in `movement.py`
- Update ADR Y-statement example to reference PostgreSQL instead of Redis

## Test plan
- [ ] Verify Docker build includes migrations directory: `docker build -t mudd . && docker run --rm mudd ls -la migrations/`
- [ ] Confirm no remaining Redis references: `grep -ri redis .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)