### PR TITLE
Add container contents support to interact command

### DIFF
--- a/mudd/cogs/interact.py
+++ b/mudd/cogs/interact.py
@@ -5,6 +5,7 @@ import logging
 from discord import Interaction, app_commands
 from discord.ext import commands
 
+from mudd.formatting.entities import build_contents_string
 from mudd.services.database import get_pool
 from mudd.services.entity import ResolvedEntity, get_entity_service
 from mudd.services.entity_matcher import (
@@ -123,9 +124,15 @@ class Interact(commands.Cog):
             await interaction.response.send_message("Nothing happens.", ephemeral=True)
             return
 
+        # Fetch container contents for template (regardless of contents_visible)
+        container_contents = await entity_service.get_container_contents(
+            entity.id, room
+        )
+        contents_str = build_contents_string(container_contents)
+
         # Render template with entity context
         try:
-            output = render(handler_text, entity)
+            output = render(handler_text, entity, contents_str)
         except TemplateRenderError:
             logger.warning(
                 "Template error rendering '%s' handler for entity '%s'",

--- a/mudd/formatting/entities.py
+++ b/mudd/formatting/entities.py
@@ -17,7 +17,7 @@ class ContainerContentsFetcher(Protocol):
     ) -> list[EntityInstance]: ...
 
 
-def _build_contents_string(contents: list[EntityInstance]) -> str:
+def build_contents_string(contents: list[EntityInstance]) -> str:
     """Build a bullet-list string from container contents.
 
     Args:
@@ -66,7 +66,7 @@ def format_entity_with_contents(
     Returns:
         Rendered description_short with contents interpolated
     """
-    contents_str = _build_contents_string(contents or [])
+    contents_str = build_contents_string(contents or [])
     return render(entity.description_short, entity, contents=contents_str)
 
 
@@ -134,7 +134,7 @@ async def render_entity_on_look(
     contents_str = ""
     if entity.contents_visible:
         contents = await entity_service.get_container_contents(entity.id, room)
-        contents_str = _build_contents_string(contents)
+        contents_str = build_contents_string(contents)
 
     # Build fallback from descriptions (also rendered as templates)
     fallback = render(

--- a/tests/test_interact_cog.py
+++ b/tests/test_interact_cog.py
@@ -33,7 +33,9 @@ def mock_visibility_service():
 @pytest.fixture
 def mock_entity_service():
     """Create a mock entity service."""
-    return MagicMock()
+    service = MagicMock()
+    service.get_container_contents = AsyncMock(return_value=[])
+    return service
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Export `build_contents_string` as public API from `mudd/formatting/entities.py`
- Use it in the interact command to populate the `contents` template variable for OnUse handlers
- Allows containers like chests to display their contents when interacted with

## Test plan
- [ ] Verify OnUse handlers can access `{{ contents }}` template variable
- [ ] Verify containers show their contents when used via `/interact use`

🤖 Generated with [Claude Code](https://claude.com/claude-code)