### PR TITLE
Add pytest to pre-commit hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,3 +21,19 @@ pre-commit:
     - name: verb duplicates check
       glob: "data/verbs/*.txt"
       run: just verbs
+
+    - name: pytest
+      exclude:
+        - "*.md"
+        - "LICENSE"
+        - ".gitignore"
+        - ".dockerignore"
+        - "Dockerfile"
+        - ".editorconfig"
+        - ".env.example"
+        - ".github/**"
+        - ".devcontainer/**"
+        - ".vscode/**"
+        - "lefthook.yml"
+        - ".squawk.toml"
+      run: uv run pytest


### PR DESCRIPTION
## Summary
- Adds pytest to lefthook pre-commit hooks to catch test failures early
- Runs tests on most file changes since tests depend on non-Python files like `.rec` data files
- Skips for documentation and config-only changes that can't affect test results

## Test plan
- [x] Verify lefthook.yml is valid
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)