### PR TITLE
Rename /interact target parameter to "with" in Discord UI

### DIFF
--- a/mudd/cogs/interact.py
+++ b/mudd/cogs/interact.py
@@ -82,13 +82,14 @@ class Interact(commands.Cog):
             )
             return []
 
-    @app_commands.command(name="interact", description="Interact with an entity")
+    @app_commands.command(name="interact", description="Interact with things")
     @app_commands.describe(
         action="Action to perform (e.g., smash, touch, take)",
         target="Thing to interact with",
     )
+    @app_commands.rename(target="with")
     @app_commands.autocomplete(target=target_autocomplete)
-    async def interact(self, interaction: Interaction, action: str, target: str):
+    async def interact(self, interaction: Interaction, target: str, action: str):
         """Interact with an entity using a verb."""
         await self.visibility_service.wait_for_startup()
 


### PR DESCRIPTION
## Summary
- Reorder `/interact` command parameters so `target` appears before `action`
- Use `@app_commands.rename` decorator to display "with" instead of "target" in the Discord UI
- Update command description from "Interact with an entity" to "Interact with things"

## Test plan
- [ ] Verify `just` passes all lint/format/type checks
- [ ] Verify all tests pass with `pytest tests/`
- [ ] Test in Discord: command should display as `/interact with:<entity> action:<verb>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)