### PR TITLE
Allow parallel devcontainer instances

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,4 @@
 {
-    "name": "mudd",
     "dockerComposeFile": "docker-compose.yml",
     "service": "app",
     "workspaceFolder": "/app",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - "5432:5432"
+      - "5432"
 
 volumes:
   postgres-data:


### PR DESCRIPTION
## Summary

- Remove hardcoded devcontainer name so it derives from the parent folder (`mudd` or `mudd-qa`)
- Use ephemeral port binding for PostgreSQL to avoid host port conflicts when running multiple devcontainers simultaneously

## Test plan

- [ ] Start devcontainer in `~/mudd`
- [ ] Start devcontainer in `~/mudd-qa` simultaneously
- [ ] Verify both containers run without port conflicts
- [ ] Verify database connectivity works in both containers

🤖 Generated with [Claude Code](https://claude.ai/code)