### PR TITLE
Add no_duplicates option to spawning pools

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -168,12 +168,14 @@ PostgreSQL is the source of truth for user locations. Discord channel permission
 | `max_count` | INTEGER NOT NULL DEFAULT 1 | Maximum items this pool maintains |
 | `respawn_interval_minutes` | INTEGER NOT NULL DEFAULT 30 | Minimum time between spawns |
 | `last_spawn_at` | TIMESTAMPTZ | When the pool last spawned an item |
+| `no_duplicates` | BOOLEAN NOT NULL DEFAULT FALSE | When TRUE, won't spawn an entity type already spawned by this pool |
 
 **Purpose:**
 - Manages automatic item respawning in rooms
 - Selects random entities matching `tag_query` when below `max_count`
 - Respects `respawn_interval_minutes` between spawns
 - Can spawn directly into room or into a container
+- With `no_duplicates`, ensures variety by preventing duplicate entity types
 
 **Constraints:**
 - FK to rooms(id) with ON DELETE CASCADE

--- a/data/worlds/mansion.rec
+++ b/data/worlds/mansion.rec
@@ -1133,7 +1133,7 @@ OnAttack: {{ effects.destroy() }}{{ effects.broadcast("**" ~ user.name ~ "** sma
 %rec: SpawningPool
 %key: Id
 %mandatory: Id Room TagQuery
-%allowed: Id Room Container TagQuery MaxCount RespawnIntervalMinutes
+%allowed: Id Room Container TagQuery MaxCount RespawnIntervalMinutes NoDuplicates
 
 Id: test_quest_map_pool
 Room: store-room
@@ -1169,3 +1169,4 @@ Container: library_desk
 TagQuery: desk_drawer_loot
 MaxCount: 2
 RespawnIntervalMinutes: 30
+NoDuplicates: yes

--- a/migrations/013_no_duplicates.sql
+++ b/migrations/013_no_duplicates.sql
@@ -1,0 +1,8 @@
+-- Add no_duplicates column to spawning_pools
+-- When TRUE, the pool will not spawn an entity type that is already spawned by the pool
+
+SET lock_timeout = '1s';
+SET statement_timeout = '5s';
+
+ALTER TABLE spawning_pools
+ADD COLUMN no_duplicates BOOLEAN NOT NULL DEFAULT FALSE;

--- a/mudd/cogs/sync.py
+++ b/mudd/cogs/sync.py
@@ -279,7 +279,7 @@ class Sync(commands.Cog):
         pool = self._pool
         now = datetime.now(UTC)
 
-        # Get all spawning pools with current instance counts
+        # Get all spawning pools with current instance counts and spawned entity IDs
         pools = await pool.fetch(
             """
             SELECT
@@ -290,7 +290,9 @@ class Sync(commands.Cog):
                 sp.max_count,
                 sp.respawn_interval_minutes,
                 sp.last_spawn_at,
-                COUNT(ei.id) AS current_count
+                sp.no_duplicates,
+                COUNT(ei.id) AS current_count,
+                ARRAY_REMOVE(ARRAY_AGG(ei.entity_id), NULL) AS spawned_entity_ids
             FROM spawning_pools sp
             LEFT JOIN entity_instances ei ON ei.spawning_pool_id = sp.id
             GROUP BY sp.id
@@ -311,14 +313,30 @@ class Sync(commands.Cog):
                     continue
 
             # Select random entity by tag with weighted rarity
-            entity = await self.entity_service.get_random_entity_by_tag(sp["tag_query"])
-            if entity is None:
-                logger.warning(
-                    "No entities found for spawning pool '%s' with tag '%s'",
-                    sp["id"],
-                    sp["tag_query"],
+            if sp["no_duplicates"]:
+                # Exclude already-spawned entity types
+                exclude_ids = set(sp["spawned_entity_ids"] or [])
+                entity = await self.entity_service.get_random_entity_by_tag_excluding(
+                    sp["tag_query"], exclude_ids
                 )
-                continue
+                if entity is None:
+                    # All entity types already spawned - skip silently
+                    logger.debug(
+                        "Pool '%s': all entity types already spawned (no_duplicates)",
+                        sp["id"],
+                    )
+                    continue
+            else:
+                entity = await self.entity_service.get_random_entity_by_tag(
+                    sp["tag_query"]
+                )
+                if entity is None:
+                    logger.warning(
+                        "No entities found for spawning pool '%s' with tag '%s'",
+                        sp["id"],
+                        sp["tag_query"],
+                    )
+                    continue
 
             # Create instance (with container if spawning pool has one)
             await pool.execute(

--- a/mudd/loaders/entity_loader.py
+++ b/mudd/loaders/entity_loader.py
@@ -347,14 +347,16 @@ async def _sync_spawning_pools(
     for pool in pools:
         await conn.execute(
             """INSERT INTO spawning_pools (
-                id, room, container_id, tag_query, max_count, respawn_interval_minutes
-            ) VALUES ($1, $2, $3, $4, $5, $6)
+                id, room, container_id, tag_query, max_count,
+                respawn_interval_minutes, no_duplicates
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)
             ON CONFLICT (id) DO UPDATE SET
                 room = $2,
                 container_id = $3,
                 tag_query = $4,
                 max_count = $5,
-                respawn_interval_minutes = $6
+                respawn_interval_minutes = $6,
+                no_duplicates = $7
             """,
             pool.id,
             pool.room,
@@ -362,6 +364,7 @@ async def _sync_spawning_pools(
             pool.tag_query,
             pool.max_count,
             pool.respawn_interval_minutes,
+            pool.no_duplicates,
         )
 
     logger.info(f"Synced {len(pools)} spawning pools")

--- a/mudd/loaders/zone_loader.py
+++ b/mudd/loaders/zone_loader.py
@@ -76,6 +76,7 @@ class SpawningPool:
     container_id: str | None = None
     max_count: int = 1
     respawn_interval_minutes: int = 30
+    no_duplicates: bool = False
 
 
 def _load_records_from_rec[T](
@@ -233,6 +234,10 @@ def _parse_spawning_pool_row(row: dict[str, str]) -> SpawningPool:
             f"'{interval_str}'. Must be an integer."
         ) from e
 
+    # Parse no_duplicates boolean
+    no_duplicates_str = row.get("NoDuplicates", "").lower()
+    no_duplicates = no_duplicates_str in ("yes", "true", "1")
+
     return SpawningPool(
         id=row["Id"],
         room=row["Room"],
@@ -240,6 +245,7 @@ def _parse_spawning_pool_row(row: dict[str, str]) -> SpawningPool:
         container_id=row.get("Container") or None,
         max_count=max_count,
         respawn_interval_minutes=respawn_interval_minutes,
+        no_duplicates=no_duplicates,
     )
 
 

--- a/mudd/services/entity.py
+++ b/mudd/services/entity.py
@@ -406,6 +406,51 @@ class EntityService:
 
         return await self.get_entity(selected_id)
 
+    async def get_random_entity_by_tag_excluding(
+        self, tag: str, exclude_entity_ids: set[str]
+    ) -> ResolvedEntity | None:
+        """Select random entity by tag, excluding specified entity IDs.
+
+        Like get_random_entity_by_tag but filters out entities with IDs
+        in exclude_entity_ids before weighted random selection.
+        Used by spawning pools with no_duplicates=True.
+
+        Args:
+            tag: Tag to filter entities by
+            exclude_entity_ids: Entity IDs to exclude from selection
+
+        Returns:
+            ResolvedEntity with weighted random selection, or None if no matches
+        """
+        candidates = await self._pool.fetch(
+            """
+            SELECT DISTINCT e.id, e.rarity
+            FROM entities e
+            JOIN entity_tags et ON e.id = et.entity_id
+            WHERE et.tag = $1 AND e.rarity != 'none'
+            """,
+            tag,
+        )
+
+        if not candidates:
+            return None
+
+        # Filter out excluded entity IDs
+        items = [
+            (candidate["id"], RARITY_WEIGHTS.get(candidate["rarity"], 0))
+            for candidate in candidates
+            if candidate["id"] not in exclude_entity_ids
+        ]
+
+        if not items:
+            return None
+
+        selected_id = weighted_choice(items)
+        if selected_id is None:
+            return None
+
+        return await self.get_entity(selected_id)
+
     def invalidate_cache(self) -> None:
         """Clear entity resolution cache.
 


### PR DESCRIPTION
## Summary
- Add `no_duplicates` boolean configuration to spawning pools
- When enabled, the pool will NOT spawn an entity type that is already spawned by the pool
- Ensures variety in spawned items when `max_count > 1`

## Changes
- New migration adding `no_duplicates` column to `spawning_pools` table
- Updated `SpawningPool` dataclass and parser to handle new field
- Added `get_random_entity_by_tag_excluding()` method to `EntityService`
- Updated spawn logic to filter already-spawned entity types when `no_duplicates` is true
- Configured `library_desk_drawer_pool` to use unique spawning
- Updated DESIGN.md documentation

## Test plan
- [x] All 236 existing tests pass
- [x] `just` checks pass (lint, format, types, squawk)
- [ ] Manual test: Create pool with `NoDuplicates: yes` and `MaxCount > 1`, verify no duplicate entity types spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)