### PR TITLE
Fix globe minibar description to hint at open action

### DIFF
--- a/data/worlds/mansion.rec
+++ b/data/worlds/mansion.rec
@@ -727,7 +727,7 @@ Prototype: furniture
 Room: lounge
 FocusMode: container
 DescriptionShort: An oversized {{ name }} sits in the corner.
-DescriptionLong: A vintage wooden globe on a brass stand. The northern hemisphere swings open to reveal a minibar stocked with bottles.
+DescriptionLong: A vintage wooden globe on a brass stand. You can __open__ the northern hemisphere to reveal the minibar inside.
 ContentsVisible: no
 OnUse: You swing open the globe and pour yourself a drink. It restores health.
 OnOpen: You swing open the northern hemisphere.{% if contents %} Inside:{{ contents }}{% else %} It's empty.{% endif %}


### PR DESCRIPTION
## Summary
- Updates the Globe Minibar's `DescriptionLong` to use the `__open__` hint pattern
- Matches the style of other containers like the Drink Fridge and Writing Desk

## Test plan
- [ ] Verify `/look Globe Minibar` shows the updated description with `__open__` hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)