### PR TITLE
Add OnUse handler and compact logo for office terminal

### DIFF
--- a/data/worlds/mansion.rec
+++ b/data/worlds/mansion.rec
@@ -365,13 +365,11 @@ FocusMode: container
 ContentsVisible: no
 DescriptionShort: An old {{ name }} hums on the desk.
 DescriptionLong: A bulky CRT monitor displaying green text on black. The case is beige plastic, yellowed with age. A small sticker reads "MUDD-OS v0.2.1".
+OnUse: The CRT hums as you press the power button. Green text flickers to life. You can now __login__.
 OnOpen: ```
-+ ███╗   ███╗██╗   ██╗██████╗ ██████╗        ██████╗ ███████╗
-+ ████╗ ████║██║   ██║██╔══██╗██╔══██╗      ██╔═══██╗██╔════╝
-+ ██╔████╔██║██║   ██║██║  ██║██║  ██║█████╗██║   ██║███████╗
-+ ██║╚██╔╝██║██║   ██║██║  ██║██║  ██║╚════╝██║   ██║╚════██║
-+ ██║ ╚═╝ ██║╚██████╔╝██████╔╝██████╔╝      ╚██████╔╝███████║
-+ ╚═╝     ╚═╝ ╚═════╝ ╚═════╝ ╚═════╝        ╚═════╝ ╚══════╝
++ ┏┳┓╻ ╻╺┳┓╺┳┓   ┏━┓┏━┓
++ ┃┃┃┃ ┃ ┃┃ ┃┃╺━╸┃ ┃┗━┓
++ ╹ ╹┗━┛╺┻┛╺┻┛   ┗━┛┗━┛
 + ```
 + *MUDD-OS v0.2.1 — Multi-User Dungeon (Discord)*
 + Welcome, GUEST. You have access to the following files:{% if contents %}{{ contents }}{% else %} (none){% endif %}


### PR DESCRIPTION
## Summary
- Add `OnUse` handler to office terminal that powers on the terminal and directs users to `__login__`
- Replace large ASCII art banner with a compact Unicode version

## Test plan
- [ ] Verify `/interact use terminal` shows the power-on message with `__login__` hint
- [ ] Verify `/interact login terminal` still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)