### PR TITLE
Fix /interact escape option printing "escape" instead of closing focus

### DIFF
--- a/mudd/cogs/interact.py
+++ b/mudd/cogs/interact.py
@@ -11,6 +11,7 @@ import discord
 from discord import Interaction, app_commands
 from discord.ext import commands
 
+from mudd.cogs.shared import handle_escape
 from mudd.commands import ActionContext, create_command
 from mudd.matching.verb_matcher import match_verb
 from mudd.services.entity import ResolvedEntity
@@ -124,7 +125,19 @@ class Interact(commands.Cog):
         result = await self.entity_resolution.resolve_target(ctx, target)
 
         if isinstance(result, ResolutionError):
-            if result.error_type == "ambiguous":
+            if result.error_type == "escape":
+                # Handle escape - clear focus and show room
+                await handle_escape(
+                    interaction,
+                    ctx,
+                    entity_resolution=self.entity_resolution,
+                    entity_service=self.entity_service,
+                    visibility_service=self.visibility_service,
+                    inventory=self._inventory,
+                    rendering=self._rendering,
+                )
+                return
+            elif result.error_type == "ambiguous":
                 await interaction.response.send_message(result.message, ephemeral=True)
             else:
                 await interaction.response.send_message(result.message, ephemeral=True)

--- a/mudd/cogs/look.py
+++ b/mudd/cogs/look.py
@@ -4,20 +4,17 @@ import logging
 from typing import TYPE_CHECKING
 
 import asyncpg
-import discord
 from discord import Interaction, app_commands
 from discord.ext import commands
 
+from mudd.cogs.shared import handle_escape
 from mudd.services.entity_resolution import ResolutionError, ViewMode
-from mudd.services.rendering import RenderingService, TemplateRenderError
+from mudd.services.rendering import RenderingService
 
 if TYPE_CHECKING:
     from mudd.services.currency import CurrencyService
     from mudd.services.entity import EntityService
-    from mudd.services.entity_resolution import (
-        EntityResolutionService,
-        InteractionContext,
-    )
+    from mudd.services.entity_resolution import EntityResolutionService
     from mudd.services.inventory import InventoryService
     from mudd.services.visibility import VisibilityServiceProtocol
 
@@ -85,7 +82,15 @@ class Look(commands.Cog):
         # Handle "Room" and empty input as escape (show room description)
         # This supports both legacy calls with at="Room" and new escape:room values
         if not at or at == "Room":
-            await self._handle_escape(interaction, ctx)
+            await handle_escape(
+                interaction,
+                ctx,
+                entity_resolution=self.entity_resolution,
+                entity_service=self.entity_service,
+                visibility_service=self.visibility_service,
+                inventory=self._inventory,
+                rendering=self._rendering,
+            )
             return
 
         # Resolve target using unified API
@@ -94,7 +99,15 @@ class Look(commands.Cog):
         if isinstance(result, ResolutionError):
             if result.error_type == "escape":
                 # Handle escape - clear focus and show room/item
-                await self._handle_escape(interaction, ctx)
+                await handle_escape(
+                    interaction,
+                    ctx,
+                    entity_resolution=self.entity_resolution,
+                    entity_service=self.entity_service,
+                    visibility_service=self.visibility_service,
+                    inventory=self._inventory,
+                    rendering=self._rendering,
+                )
                 return
             elif result.error_type == "ambiguous":
                 # Disambiguation prompt
@@ -150,85 +163,3 @@ class Look(commands.Cog):
             matched_instance, self.entity_service, render_room, balance_str
         )
         await interaction.response.send_message(detail_text, ephemeral=True)
-
-    async def _handle_escape(
-        self, interaction: Interaction, ctx: "InteractionContext"
-    ) -> None:
-        """Handle escape action (close focus, show room or thread item)."""
-        user_id = interaction.user.id
-        room = ctx.room
-
-        if ctx.view_mode == ViewMode.INVENTORY_THREAD and ctx.thread_instance_id:
-            # In inventory thread container - close focus and show the container
-            await self.entity_resolution.clear_focus(user_id, reason="close")
-
-            # Get thread item and show it
-            channel = interaction.channel
-            if isinstance(channel, (discord.abc.GuildChannel, discord.Thread)):
-                thread_item = await self._inventory.get_thread_item(channel)
-                if thread_item:
-                    detail_text = await self._rendering.render_entity_on_look(
-                        thread_item,
-                        self.entity_service,
-                        None,
-                        include_heading=False,  # Thread title shows the item name
-                    )
-                    await interaction.response.send_message(detail_text, ephemeral=True)
-                    return
-
-            await interaction.response.send_message(
-                "You see nothing special.", ephemeral=True
-            )
-            return
-
-        # Room escape - clear focus and show room
-        close_msg = None
-
-        # Get focus to capture entity before clearing (for template rendering)
-        focus = await self.entity_resolution.get_focus(user_id, room)
-        focused_entity = None
-        if focus:
-            focused_entity = await self.entity_service.get_entity(focus.entity_id)
-
-        # Clear focus with "close" reason to get on_close template
-        close_template = await self.entity_resolution.clear_focus(
-            user_id, reason="close"
-        )
-
-        # Render close message if we have template and entity
-        if close_template and focused_entity:
-            try:
-                close_msg = self._rendering.render(close_template, focused_entity, "")
-            except TemplateRenderError:
-                logger.warning(
-                    "Template error rendering on_close for entity '%s'",
-                    focused_entity.id,
-                    exc_info=True,
-                )
-                entity_name = focused_entity.name
-                close_msg = f"You step away from the *{entity_name}*."
-
-        # Show room description + top-level entities
-        room_name = await self.visibility_service.get_room_name(room) if room else None
-        topic = getattr(interaction.channel, "topic", None)
-        room_description = topic or "You see nothing special."
-
-        entity_text = ""
-        if room:
-            entities = await self.entity_service.get_top_level_room_entities(room)
-            entity_text = await self._rendering.format_room_entities(
-                entities, self.entity_service, room
-            )
-
-        # Build message, prepending close message if present
-        parts = []
-        if close_msg:
-            parts.append(close_msg)
-        if room_name:
-            parts.append(f"### {room_name}")
-        parts.append(room_description)
-        if entity_text:
-            parts.append(entity_text)
-
-        message = "\n\n".join(parts)
-        await interaction.response.send_message(message, ephemeral=True)

--- a/mudd/cogs/shared.py
+++ b/mudd/cogs/shared.py
@@ -1,0 +1,121 @@
+"""Shared utilities for cogs."""
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+from discord import Interaction
+
+from mudd.services.entity_resolution import ViewMode
+from mudd.services.rendering import RenderingService, TemplateRenderError
+
+if TYPE_CHECKING:
+    from mudd.services.entity import EntityService
+    from mudd.services.entity_resolution import (
+        EntityResolutionService,
+        InteractionContext,
+    )
+    from mudd.services.inventory import InventoryService
+    from mudd.services.visibility import VisibilityServiceProtocol
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_escape(
+    interaction: Interaction,
+    ctx: "InteractionContext",
+    *,
+    entity_resolution: "EntityResolutionService",
+    entity_service: "EntityService",
+    visibility_service: "VisibilityServiceProtocol",
+    inventory: "InventoryService",
+    rendering: RenderingService,
+) -> None:
+    """Handle escape action (close focus, show room or thread item).
+
+    This is shared between /look and /interact commands.
+
+    Args:
+        interaction: Discord interaction
+        ctx: Interaction context from entity resolution
+        entity_resolution: Service for focus management
+        entity_service: Service for entity lookups
+        visibility_service: Service for room name lookups
+        inventory: Service for inventory thread lookups
+        rendering: Service for template rendering
+    """
+    user_id = interaction.user.id
+    room = ctx.room
+
+    if ctx.view_mode == ViewMode.INVENTORY_THREAD and ctx.thread_instance_id:
+        # In inventory thread container - close focus and show the container
+        await entity_resolution.clear_focus(user_id, reason="close")
+
+        # Get thread item and show it
+        channel = interaction.channel
+        if isinstance(channel, (discord.abc.GuildChannel, discord.Thread)):
+            thread_item = await inventory.get_thread_item(channel)
+            if thread_item:
+                detail_text = await rendering.render_entity_on_look(
+                    thread_item,
+                    entity_service,
+                    None,
+                    include_heading=False,  # Thread title shows the item name
+                )
+                await interaction.response.send_message(detail_text, ephemeral=True)
+                return
+
+        await interaction.response.send_message(
+            "You see nothing special.", ephemeral=True
+        )
+        return
+
+    # Room escape - clear focus and show room
+    close_msg = None
+
+    # Get focus to capture entity before clearing (for template rendering)
+    focus = await entity_resolution.get_focus(user_id, room)
+    focused_entity = None
+    if focus:
+        focused_entity = await entity_service.get_entity(focus.entity_id)
+
+    # Clear focus with "close" reason to get on_close template
+    close_template = await entity_resolution.clear_focus(user_id, reason="close")
+
+    # Render close message if we have template and entity
+    if close_template and focused_entity:
+        try:
+            close_msg = rendering.render(close_template, focused_entity, "")
+        except TemplateRenderError:
+            logger.warning(
+                "Template error rendering on_close for entity '%s'",
+                focused_entity.id,
+                exc_info=True,
+            )
+            entity_name = focused_entity.name
+            close_msg = f"You step away from the *{entity_name}*."
+
+    # Show room description + top-level entities
+    room_name = await visibility_service.get_room_name(room) if room else None
+    topic = getattr(interaction.channel, "topic", None)
+    room_description = topic or "You see nothing special."
+
+    entity_text = ""
+    if room:
+        entities = await entity_service.get_top_level_room_entities(room)
+        entity_text = await rendering.format_room_entities(
+            entities, entity_service, room
+        )
+
+    # Build message, prepending close message if present
+    parts = []
+    if close_msg:
+        parts.append(close_msg)
+    if room_name:
+        parts.append(f"### {room_name}")
+    parts.append(room_description)
+    if entity_text:
+        parts.append(entity_text)
+
+    message = "\n\n".join(parts)
+    await interaction.response.send_message(message, ephemeral=True)


### PR DESCRIPTION
## Summary

- Fixed bug where selecting "[Close X] Room" escape option via `/interact` printed literal text "escape" instead of closing focus and showing the room
- Extracted shared escape handling logic into `mudd/cogs/shared.py` to avoid duplication between `/look` and `/interact` commands

## Test plan

- [ ] Focus on a container (e.g., `/look at:Wooden Chest`)
- [ ] Run `/interact with:"[Close Wooden Chest] Room" action:touch` (or any verb)
- [ ] Verify the focus is cleared, the on_close template renders, and the room description is shown
- [ ] Verify `/look` escape still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)