### PR TITLE
chore: Clean up Claude Code config and add healtests skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,11 +1,3 @@
 {
-  "enabledPlugins": {
-    "pr-review-toolkit@claude-code-plugins": true,
-    "code-review@claude-code-plugins": true,
-    "commit-commands@claude-code-plugins": true,
-    "feature-dev@claude-plugins-official": true,
-    "code-review@claude-plugins-official": true,
-    "commit-commands@claude-plugins-official": true,
-    "pr-review-toolkit@claude-plugins-official": true
-  }
+  "enabledPlugins": {}
 }

--- a/.claude/skills/healtests/SKILL.md
+++ b/.claude/skills/healtests/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: healtests
+description: Iteratively fix test failures until all tests pass. Use when tests are failing and you want Claude to automatically plan and fix them in a loop.
+disable-model-invocation: true
+---
+
+# Heal Tests Loop
+
+You are in a test-healing loop. Goal: make all tests pass.
+
+## Step 1: Run Tests
+
+```bash
+just testq
+```
+
+## Step 2: Evaluate Results
+
+**If tests pass**: Report success. The healing loop is complete.
+
+**If tests fail**: Continue to Step 3.
+
+## Step 3: Plan the Fix
+
+1. Analyze the test failure output
+2. Enter plan mode using `EnterPlanMode` tool
+3. Write your fix plan to the plan file
+
+**CRITICAL**: Your plan file MUST end with this exact section:
+
+```markdown
+## Verification (Healing Loop)
+
+This fix is part of a `/healtests` healing loop. After implementing:
+
+1. Run `just testq`
+2. If tests pass, the healing loop is complete
+3. If tests fail, use `EnterPlanMode` to plan the next fix
+
+The loop continues until all tests pass.
+```
+
+This ensures the loop context survives context clearing.


### PR DESCRIPTION
## Summary
- Remove unused plugin entries from `.claude/settings.json`
- Add `/healtests` skill for iteratively fixing test failures in a loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)