### PR TITLE
Add Coverage Gutters extension to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,8 @@
                 "editorconfig.editorconfig",
                 "ms-python.python",
                 "ms-ossdata.vscode-pgsql",
-                "vstirbu.vscode-mermaid-preview"
+                "vstirbu.vscode-mermaid-preview",
+                "ryanluker.vscode-coverage-gutters"
             ]
         }
     },


### PR DESCRIPTION
## Summary
- Adds the `ryanluker.vscode-coverage-gutters` VS Code extension to the devcontainer configuration for inline test coverage visualization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)