### PR TITLE
Add XP delta indicators to skills overview

### DIFF
--- a/mudd/observers/skills_reconciler.py
+++ b/mudd/observers/skills_reconciler.py
@@ -22,6 +22,7 @@ from mudd.skills.formatting import (
     format_skills_message,
     get_milestone_role,
 )
+from mudd.skills.registry import Skill
 
 logger = logging.getLogger(__name__)
 
@@ -128,10 +129,13 @@ class SkillsReconciler:
         user_left_events = self._user_left_events
         self._user_left_events = []
 
-        # Collect unique user IDs that need updates
+        # Collect unique user IDs that need updates and aggregate deltas
         user_ids: set[int] = set()
+        user_deltas: dict[int, dict[Skill, int]] = {}
         for evt in xp_events:
             user_ids.add(evt.user_id)
+            deltas = user_deltas.setdefault(evt.user_id, {})
+            deltas[evt.skill] = deltas.get(evt.skill, 0) + (evt.new_xp - evt.old_xp)
         for evt in level_up_events:
             user_ids.add(evt.user_id)
 
@@ -139,9 +143,12 @@ class SkillsReconciler:
         for user_id in user_ids:
             skills = await UserSkill.get_all(self._pool, user_id)
             total_level = sum(s.level for s in skills)
+            deltas = user_deltas.get(user_id)
 
             try:
-                await self._update_skills_channel(user_id, skills, total_level)
+                await self._update_skills_channel(
+                    user_id, skills, total_level, deltas=deltas
+                )
             except Exception:
                 logger.exception(
                     "Failed to update skills channel for user %d",
@@ -364,6 +371,8 @@ class SkillsReconciler:
         user_id: int,
         skills: list[UserSkill],
         total_level: int,
+        *,
+        deltas: dict[Skill, int] | None = None,
     ) -> None:
         """Update the skills overview message in the user's channel.
 
@@ -371,6 +380,7 @@ class SkillsReconciler:
             user_id: Discord user ID
             skills: Pre-fetched list of user skills
             total_level: Pre-computed total level
+            deltas: Optional XP deltas per skill to show (+N) indicators
         """
         record = await UserSkillsChannel.get(self._pool, user_id)
         if record is None:
@@ -387,7 +397,7 @@ class SkillsReconciler:
         # Build message content
         member = channel.guild.get_member(user_id)
         display_name = member.display_name if member else str(user_id)
-        content = format_skills_message(skills, total_level, display_name)
+        content = format_skills_message(skills, total_level, display_name, deltas)
 
         if message_id is not None:
             # Try to edit existing message

--- a/mudd/skills/formatting.py
+++ b/mudd/skills/formatting.py
@@ -55,7 +55,10 @@ def format_progress_bar(current_xp: int, level: int) -> str:
 
 
 def format_skills_message(
-    skills: list[UserSkill], total_level: int, display_name: str
+    skills: list[UserSkill],
+    total_level: int,
+    display_name: str,
+    deltas: dict[Skill, int] | None = None,
 ) -> str:
     """Format the full skills overview message.
 
@@ -66,6 +69,7 @@ def format_skills_message(
         skills: List of UserSkill instances
         total_level: Sum of all skill levels
         display_name: Player's display name
+        deltas: Optional map of skill to XP gained, shown as (+N) indicator
 
     Returns:
         Formatted Discord message string
@@ -84,6 +88,9 @@ def format_skills_message(
             xp = user_skill.xp
 
         bar = format_progress_bar(xp, level)
+        delta = deltas.get(skill_enum, 0) if deltas else 0
+        if delta:
+            bar = f"{bar} (+{delta}) \U0001f199"
         lines.append(f"{ViewSkill(skill_enum)} LV{level}")
         lines.append(bar)
         lines.append("")

--- a/mudd/skills/formatting_unit_test.py
+++ b/mudd/skills/formatting_unit_test.py
@@ -90,6 +90,50 @@ class TestFormatSkillsMessage:
             assert "`" in line
 
 
+class TestFormatSkillsMessageDeltas:
+    _skills = [
+        UserSkill(user_id=1, skill="agility", xp=0, level=1),
+        UserSkill(user_id=1, skill="attack", xp=25, level=1),
+        UserSkill(user_id=1, skill="speech", xp=0, level=1),
+        UserSkill(user_id=1, skill="vitality", xp=0, level=1),
+        UserSkill(user_id=1, skill="fishing", xp=0, level=1),
+    ]
+
+    def test_no_deltas_no_indicator(self) -> None:
+        msg = format_skills_message(self._skills, 5, "Alice")
+        assert "(+" not in msg
+
+    def test_none_deltas_no_indicator(self) -> None:
+        msg = format_skills_message(self._skills, 5, "Alice", deltas=None)
+        assert "(+" not in msg
+
+    def test_single_delta_shown(self) -> None:
+        msg = format_skills_message(self._skills, 5, "Alice", deltas={Skill.ATTACK: 25})
+        assert "(+25) \U0001f199" in msg
+
+    def test_delta_only_on_matching_skill(self) -> None:
+        msg = format_skills_message(self._skills, 5, "Alice", deltas={Skill.ATTACK: 25})
+        lines = msg.split("\n")
+        bar_lines = [line for line in lines if "XP" in line]
+        # Only the Attack bar line should have the indicator
+        lines_with_delta = [line for line in bar_lines if "(+25)" in line]
+        assert len(lines_with_delta) == 1
+
+    def test_multiple_deltas(self) -> None:
+        msg = format_skills_message(
+            self._skills,
+            5,
+            "Alice",
+            deltas={Skill.ATTACK: 25, Skill.AGILITY: 10},
+        )
+        assert "(+25) \U0001f199" in msg
+        assert "(+10) \U0001f199" in msg
+
+    def test_zero_delta_not_shown(self) -> None:
+        msg = format_skills_message(self._skills, 5, "Alice", deltas={Skill.ATTACK: 0})
+        assert "(+" not in msg
+
+
 class TestFormatNickname:
     def test_basic_format(self) -> None:
         assert format_nickname("Alice", 15) == "Alice (LV15)"

--- a/mudd/utils/progress_bar.py
+++ b/mudd/utils/progress_bar.py
@@ -7,7 +7,7 @@ Unicode block shading characters ░▒▓█.
 from __future__ import annotations
 
 SHADED = "░▒▓█"
-DEFAULT_SIZE = 20
+DEFAULT_SIZE = 16
 
 
 def shaded_bar(percent: float, size: int = DEFAULT_SIZE) -> str:

--- a/mudd/utils/progress_bar_unit_test.py
+++ b/mudd/utils/progress_bar_unit_test.py
@@ -30,11 +30,12 @@ class TestShadedBar:
 
     def test_50_percent_half_filled(self) -> None:
         bar = shaded_bar(50)
-        # Exactly 50% should have 10 full blocks and 10 empty, no partial
+        # Exactly 50% should have half full blocks and half empty, no partial
+        half = DEFAULT_SIZE // 2
         full_count = bar.count("█")
         empty_count = bar.count("░")
-        assert full_count == 10
-        assert empty_count == 10
+        assert full_count == half
+        assert empty_count == half
 
     def test_small_percent_shows_partial(self) -> None:
         bar = shaded_bar(1)


### PR DESCRIPTION
## Summary
- Show `(+N) 🆙` indicators on skill progress bars when XP is gained, giving players immediate visual feedback
- Aggregate multiple XP events per skill before rendering the delta
- Shrink progress bar from 20 to 16 characters to accommodate the indicator without overflow
- Fix progress bar unit test to use `DEFAULT_SIZE` constant instead of hardcoded values

## Test plan
- [x] Unit tests for delta display (single, multiple, zero, none)
- [x] Existing formatting and progress bar tests updated and passing
- [x] Verify in Discord that the `(+N) 🆙` indicator appears on XP gain and clears on next update

🤖 Generated with [Claude Code](https://claude.com/claude-code)