### PR TITLE
Add GUILD_ID env var to restrict bot to a single guild

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # This is an example .env file. Copy this to .env and fill in the values.
 DISCORD_TOKEN=XXXX
 
+# Discord guild (server) ID — required, restricts the bot to a single guild
+GUILD_ID=
+
 # PostgreSQL connection URL
 DATABASE_URL=postgresql://mudd:mudd@db:5432/mudd
 

--- a/main.py
+++ b/main.py
@@ -51,7 +51,10 @@ intents.message_content = True
 args = parse_args()
 # Empty prefix tuple disables prefix command parsing — this bot
 # uses slash commands and on_message listeners only.
-bot = MuddBot(world_file=args.world, command_prefix=(), intents=intents)
+guild_id = int(os.environ["GUILD_ID"])
+bot = MuddBot(
+    world_file=args.world, guild_id=guild_id, command_prefix=(), intents=intents
+)
 
 
 @bot.event
@@ -82,7 +85,9 @@ async def setup_hook():
 async def on_ready():
     # Sync cog handles zone/room sync and room cache initialization
     # on first periodic_sync iteration. This just syncs slash commands.
-    await bot.tree.sync()
+    guild = discord.Object(id=bot.guild_id)
+    bot.tree.copy_global_to(guild=guild)
+    await bot.tree.sync(guild=guild)
     logger.info(f"Logged in as {bot.user} (world: {bot.world_file})")
 
 

--- a/mudd/bot.py
+++ b/mudd/bot.py
@@ -1,5 +1,10 @@
-from pathlib import Path
+from __future__ import annotations
 
+from pathlib import Path
+from typing import override
+
+import discord
+from discord import app_commands
 from discord.ext import commands
 
 from mudd.database import close_pool
@@ -8,10 +13,19 @@ from mudd.database import close_pool
 class MuddBot(commands.Bot):
     """MUDD Discord bot with world file configuration."""
 
-    def __init__(self, world_file: Path, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, world_file: Path, *, guild_id: int, **kwargs):
+        super().__init__(tree_cls=MuddCommandTree, **kwargs)
         self.world_file = world_file
+        self.guild_id = guild_id
 
     async def close(self):
         await close_pool()
         await super().close()
+
+
+class MuddCommandTree(app_commands.CommandTree[MuddBot]):
+    """Command tree that blocks interactions from non-whitelisted guilds."""
+
+    @override
+    async def interaction_check(self, interaction: discord.Interaction, /) -> bool:
+        return interaction.guild_id == self.client.guild_id

--- a/mudd/cogs/movement.py
+++ b/mudd/cogs/movement.py
@@ -20,6 +20,7 @@ from mudd.observers import (
 )
 
 if TYPE_CHECKING:
+    from mudd.bot import MuddBot
     from mudd.caches.user import UserCache
 
 logger = logging.getLogger(__name__)
@@ -218,6 +219,9 @@ class Movement(commands.Cog):
     @commands.Cog.listener()
     async def on_member_join(self, member: discord.Member):
         """Assign new members to the default location and create inventory forum."""
+        bot: MuddBot = self.bot  # type: ignore[assignment]
+        if member.guild.id != bot.guild_id:
+            return
         if member.bot:
             return
 
@@ -256,6 +260,9 @@ class Movement(commands.Cog):
     @commands.Cog.listener()
     async def on_member_remove(self, member: discord.Member):
         """Clean up user data when member leaves."""
+        bot: MuddBot = self.bot  # type: ignore[assignment]
+        if member.guild.id != bot.guild_id:
+            return
         try:
             # Create reconciler and emit event
             reconciler = DiscordReconciler(

--- a/mudd/cogs/racing.py
+++ b/mudd/cogs/racing.py
@@ -7,11 +7,15 @@ import logging
 import random
 from dataclasses import dataclass
 from io import BytesIO
+from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
 
 import asyncpg
 import discord
 from discord.ext import commands, tasks
+
+if TYPE_CHECKING:
+    from mudd.bot import MuddBot
 
 from mudd.models.horse import Horse
 from mudd.observers import RoomChannelCache
@@ -533,9 +537,11 @@ def _build_message_queue(
 class Racing(commands.Cog):
     """Horse racing integration — triggers races and posts to Discord."""
 
+    bot: MuddBot
+
     def __init__(
         self,
-        bot: commands.Bot,
+        bot: MuddBot,
         pool: asyncpg.Pool,
         room_cache: RoomChannelCache,
     ) -> None:
@@ -555,6 +561,9 @@ class Racing(commands.Cog):
     async def on_message(self, message: discord.Message) -> None:
         """Listen for !horse command in the race-track channel."""
         if message.author.bot or message.guild is None:
+            return
+
+        if message.guild.id != self.bot.guild_id:
             return
 
         if message.content.strip().lower() != "!horse":
@@ -810,7 +819,7 @@ class Racing(commands.Cog):
         end_time: dt.datetime,
     ) -> None:
         """Create a Discord scheduled event for the race (best-effort)."""
-        guild = self.bot.guilds[0] if self.bot.guilds else None
+        guild = self.bot.get_guild(self.bot.guild_id)
         if guild is None:
             return
         try:
@@ -830,7 +839,7 @@ class Racing(commands.Cog):
 
     async def _start_discord_event(self, race_id: int) -> None:
         """Start the Discord scheduled event for a race (best-effort)."""
-        guild = self.bot.guilds[0] if self.bot.guilds else None
+        guild = self.bot.get_guild(self.bot.guild_id)
         if guild is None:
             return
         event_id = await get_scheduled_event_id(self._pool, race_id)
@@ -845,7 +854,7 @@ class Racing(commands.Cog):
 
     async def _end_discord_event(self, race_id: int) -> None:
         """End the Discord scheduled event for a race (best-effort)."""
-        guild = self.bot.guilds[0] if self.bot.guilds else None
+        guild = self.bot.get_guild(self.bot.guild_id)
         if guild is None:
             return
         event_id = await get_scheduled_event_id(self._pool, race_id)
@@ -937,7 +946,7 @@ class Racing(commands.Cog):
                 BytesIO(msg.image_data), filename=msg.image_name
             )
 
-        guild = self.bot.guilds[0] if self.bot.guilds else None
+        guild = self.bot.get_guild(self.bot.guild_id)
         if guild is None:
             logger.warning("No guild available for race message")
             return False, None

--- a/mudd/cogs/speech.py
+++ b/mudd/cogs/speech.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import TYPE_CHECKING
 
 import asyncpg
 import discord
 from discord.ext import commands
+
+if TYPE_CHECKING:
+    from mudd.bot import MuddBot
 
 from mudd.events.types import GrantXPSignal
 from mudd.models.user import User
@@ -42,6 +46,10 @@ class Speech(commands.Cog):
         """Grant Speech XP for messages in room channels."""
         # Skip bots and DMs
         if message.author.bot or message.guild is None:
+            return
+
+        bot: MuddBot = self.bot  # type: ignore[assignment]
+        if message.guild.id != bot.guild_id:
             return
 
         # Only grant XP in room channels

--- a/mudd/cogs/sync.py
+++ b/mudd/cogs/sync.py
@@ -214,68 +214,71 @@ class Sync(commands.Cog):
         except Exception:
             logger.exception("Failed to report orphans")
 
-        for guild in self.bot.guilds:
-            logger.info(f"Starting remaining sync for {guild.name}")
+        guild = self.bot.get_guild(self.bot.guild_id)
+        if guild is None:
+            logger.warning("Whitelisted guild not available — skipping remaining sync")
+            return
 
-            # Rebuild room cache after channels are created
-            try:
-                await self.room_cache.rebuild(guild)
-            except Exception:
-                logger.exception(f"Failed to rebuild room cache for {guild.name}")
-                if fail_fast:
-                    raise
+        logger.info(f"Starting remaining sync for {guild.name}")
 
-            # Create reconciler with room_cache for permission sync
-            perm_reconciler = DiscordReconciler(
-                self.bot,
-                pool,
-                room_cache=self.room_cache,
-                console_channel=self._console_channel,
-            )
+        # Rebuild room cache after channels are created
+        try:
+            await self.room_cache.rebuild(guild)
+        except Exception:
+            logger.exception(f"Failed to rebuild room cache for {guild.name}")
+            if fail_fast:
+                raise
 
-            # Visibility sync via UserLocationSyncEvent
-            try:
-                vis_stats = await self._sync_user_visibility(guild, perm_reconciler)
-                logger.info(f"Visibility sync for {guild.name}: {vis_stats}")
-            except Exception:
-                logger.exception(f"Failed visibility sync for {guild.name}")
-                if fail_fast:
-                    raise
+        # Create reconciler with room_cache for permission sync
+        perm_reconciler = DiscordReconciler(
+            self.bot,
+            pool,
+            room_cache=self.room_cache,
+            console_channel=self._console_channel,
+        )
 
-            # Inventory sync via unified event (forums, wallets, threads, descriptions)
-            # Reset stats before sync
-            perm_reconciler.reset_inventory_forum_stats()
-            member_count = 0
-            for member in guild.members:
-                if not member.bot:
-                    member_count += 1
-                    perm_reconciler.notify(
-                        InventorySyncEvent(guild_id=guild.id, user_id=member.id)
-                    )
+        # Visibility sync via UserLocationSyncEvent
+        try:
+            vis_stats = await self._sync_user_visibility(guild, perm_reconciler)
+            logger.info(f"Visibility sync for {guild.name}: {vis_stats}")
+        except Exception:
+            logger.exception(f"Failed visibility sync for {guild.name}")
+            if fail_fast:
+                raise
 
-            try:
-                await perm_reconciler.flush()
-                inv_stats = perm_reconciler.get_inventory_forum_stats()
-                logger.info(
-                    f"Inventory sync for {guild.name}: "
-                    f"{member_count} users, {inv_stats}"
+        # Inventory sync via unified event (forums, wallets, threads, descriptions)
+        # Reset stats before sync
+        perm_reconciler.reset_inventory_forum_stats()
+        member_count = 0
+        for member in guild.members:
+            if not member.bot:
+                member_count += 1
+                perm_reconciler.notify(
+                    InventorySyncEvent(guild_id=guild.id, user_id=member.id)
                 )
-            except Exception:
-                logger.exception(f"Failed inventory sync for {guild.name}")
 
-            # Skills sync: channels, nicknames, milestone roles
-            try:
-                await self._sync_skills(guild, pool)
-            except Exception:
-                logger.exception(f"Failed skills sync for {guild.name}")
+        try:
+            await perm_reconciler.flush()
+            inv_stats = perm_reconciler.get_inventory_forum_stats()
+            logger.info(
+                f"Inventory sync for {guild.name}: {member_count} users, {inv_stats}"
+            )
+        except Exception:
+            logger.exception(f"Failed inventory sync for {guild.name}")
 
-            # Recurring race event sync
-            try:
-                await self._sync_recurring_race_event(guild, fail_fast=fail_fast)
-            except Exception:
-                logger.exception(f"Failed recurring race event sync for {guild.name}")
-                if fail_fast:
-                    raise
+        # Skills sync: channels, nicknames, milestone roles
+        try:
+            await self._sync_skills(guild, pool)
+        except Exception:
+            logger.exception(f"Failed skills sync for {guild.name}")
+
+        # Recurring race event sync
+        try:
+            await self._sync_recurring_race_event(guild, fail_fast=fail_fast)
+        except Exception:
+            logger.exception(f"Failed recurring race event sync for {guild.name}")
+            if fail_fast:
+                raise
 
         if fail_fast:
             logger.info("Initial sync complete")
@@ -515,26 +518,29 @@ class Sync(commands.Cog):
             room_ids: Set of valid room IDs
             reconciler: DiscordReconciler to notify of orphans
         """
-        for guild in self.bot.guilds:
-            for zone in zones:
-                # Find category for this zone
-                normalized_name = zone.name.lower().replace(" ", "-")
-                category = None
-                for cat in guild.categories:
-                    if cat.name.lower().replace(" ", "-") == normalized_name:
-                        category = cat
-                        break
+        guild = self.bot.get_guild(self.bot.guild_id)
+        if guild is None:
+            return
 
-                if category is None:
-                    continue
+        for zone in zones:
+            # Find category for this zone
+            normalized_name = zone.name.lower().replace(" ", "-")
+            category = None
+            for cat in guild.categories:
+                if cat.name.lower().replace(" ", "-") == normalized_name:
+                    category = cat
+                    break
 
-                # Find orphan channels in this category
-                for channel in category.channels:
-                    if channel.name not in room_ids:
-                        reconciler.notify(
-                            OrphanChannelDetectedEvent(
-                                guild_id=guild.id,
-                                channel_name=channel.name,
-                                category_name=category.name,
-                            )
+            if category is None:
+                continue
+
+            # Find orphan channels in this category
+            for channel in category.channels:
+                if channel.name not in room_ids:
+                    reconciler.notify(
+                        OrphanChannelDetectedEvent(
+                            guild_id=guild.id,
+                            channel_name=channel.name,
+                            category_name=category.name,
                         )
+                    )


### PR DESCRIPTION
## Summary
- Adds required `GUILD_ID` environment variable that restricts all bot activity to a single Discord guild
- Gates slash commands via a `MuddCommandTree` subclass with `interaction_check`, and gates event listeners (`on_member_join`, `on_member_remove`, `on_message`) with early-return guild ID checks
- Replaces `bot.guilds[0]` lookups and `for guild in bot.guilds` loops with direct `get_guild()` calls
- Switches command sync from global to guild-scoped (`copy_global_to` + `sync(guild=...)`) for near-instant slash command availability

## Test plan
- [x] `just` passes (lint, format, types, vulture, 319 tests)
- [ ] Confirm bot refuses to start without `GUILD_ID` set
- [ ] Confirm slash commands sync to specific guild
- [ ] Confirm listeners in movement/speech/racing early-return for wrong guild

🤖 Generated with [Claude Code](https://claude.com/claude-code)