### PR TITLE
Fix linear scan in extract_exits_from_topic and voice permission no-op check

### DIFF
--- a/mudd/cogs/movement.py
+++ b/mudd/cogs/movement.py
@@ -29,19 +29,20 @@ PLAINTEXT_CHANNEL_PATTERN = re.compile(r"#([\w-]+)")
 
 
 def extract_exits_from_topic(
-    topic: str | None, guild: discord.Guild
+    topic: str | None, guild: discord.Guild, room_cache: RoomChannelCache
 ) -> list[discord.TextChannel]:
     """Extract valid exit channels from a channel's topic (plaintext #channel-name)."""
     if not topic:
         return []
 
-    channel_by_name = {ch.name.lower(): ch for ch in guild.text_channels}
-
     exits: list[discord.TextChannel] = []
     for match in PLAINTEXT_CHANNEL_PATTERN.finditer(topic):
         name = match.group(1).lower()
-        if name in channel_by_name:
-            exits.append(channel_by_name[name])
+        channel_id = room_cache.get_channel_for_room(name)
+        if channel_id is not None:
+            channel = guild.get_channel(channel_id)
+            if isinstance(channel, discord.TextChannel):
+                exits.append(channel)
 
     return exits
 
@@ -95,7 +96,9 @@ class Movement(commands.Cog):
 
         channel = interaction.channel
         topic = getattr(channel, "topic", None)
-        valid_exits = extract_exits_from_topic(topic, interaction.guild)
+        valid_exits = extract_exits_from_topic(
+            topic, interaction.guild, self.room_cache
+        )
 
         # Filter exits based on current input (case-insensitive)
         current_lower = current.lower()
@@ -128,7 +131,9 @@ class Movement(commands.Cog):
 
         channel = interaction.channel
         topic = getattr(channel, "topic", None)
-        valid_exits = extract_exits_from_topic(topic, interaction.guild)
+        valid_exits = extract_exits_from_topic(
+            topic, interaction.guild, self.room_cache
+        )
 
         if not valid_exits:
             await interaction.response.send_message(

--- a/mudd/observers/permissions.py
+++ b/mudd/observers/permissions.py
@@ -108,7 +108,10 @@ class PermissionReconciler:
 
         # Skip API call if voice permissions already match desired state
         current = paired_voice.overwrites_for(member)
-        if overwrite is None and current.is_empty():
+        if overwrite is None:
+            if current.is_empty():
+                return
+        elif current == overwrite:
             return
 
         try:


### PR DESCRIPTION
## Summary

- **`extract_exits_from_topic`**: Replace O(n) linear scan of `guild.text_channels` with O(1) `RoomChannelCache` lookups. This dict was rebuilt on every autocomplete keystroke and `/move` command.
- **`_set_voice_permissions`**: Extend no-op check to skip redundant `set_permissions` API calls for the grant case (previously only skipped for the revoke case), avoiding unnecessary Discord API PUT requests and potential 429 rate limits.

## Test plan

- [x] All 319 tests pass
- [x] Lint, format, and type checks pass
- [ ] Verify `/move` command still works in Discord (autocomplete + movement)
- [ ] Verify voice channel permissions are correctly granted/revoked on movement

🤖 Generated with [Claude Code](https://claude.com/claude-code)