### PR TITLE
Replace yen (¥) with generic currency sign (¤)

### DIFF
--- a/.claude/skills/terminal-changelog/SKILL.md
+++ b/.claude/skills/terminal-changelog/SKILL.md
@@ -71,7 +71,7 @@ Insert after the previous terminal_inbox entry, before `# Gallery entities`.
 
 **Include gameplay tips:**
 - Where to find new things ("Check the lounge for the slot machine")
-- How to use new features ("Use /pay to send yen to nearby players")
+- How to use new features ("Use /pay to send money to nearby players")
 - Fun interactions ("Pull the handle to win prizes!")
 
 **Tone:** Casual dev update from Frizzle. Excited about new features, hints at what's coming.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -249,7 +249,7 @@ PostgreSQL is the source of truth for user locations. Discord channel permission
 | Column | Type | Description |
 |--------|------|-------------|
 | `user_id` | BIGINT (PK) | Discord user ID (0 is house account) |
-| `balance` | BIGINT NOT NULL | Current balance in yen (must be >= 0) |
+| `balance` | BIGINT NOT NULL | Current balance (must be >= 0) |
 | `wallet_instance_id` | UUID (FK to entity_instances.id) | Player's wallet entity instance |
 | `created_at` | TIMESTAMPTZ NOT NULL | When the account was created |
 
@@ -440,7 +440,7 @@ PostgreSQL is the source of truth for user locations. Discord channel permission
 | `race_id` | INT NOT NULL (FK to races.id) | Race being bet on |
 | `horse_id` | TEXT NOT NULL (FK to horses.id) | Horse being bet on |
 | `user_id` | BIGINT NOT NULL | Discord user who placed the bet |
-| `amount` | INT NOT NULL | Bet amount in yen (must be > 0) |
+| `amount` | INT NOT NULL | Bet amount (must be > 0) |
 | `payout` | INT | Payout amount (NULL until race finishes) |
 | `created_at` | TIMESTAMPTZ NOT NULL | When the bet was placed |
 

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@
 - `/look at:<entity>` - Examine a specific entity in the room
 - `/move <destination>` - Move to another room (exits listed in current room's topic)
 - `/interact with:<entity> action:<verb>` - Interact with an entity (e.g., smash, touch, take)
-- `/pay to:<player> amount:<number>` - Give yen to another player in the same room
+- `/pay to:<player> amount:<number>` - Give currency to another player in the same room

--- a/data/worlds/mansion.rec
+++ b/data/worlds/mansion.rec
@@ -257,7 +257,7 @@ OnUse: You whip out your wallet, it has **{{ user.balance|money }}**.
 OnOpen: You open up your wallet, inside it has **{{ user.balance|money }}**.
 
 # ----------------------------------------------------------------------------
-# Currency pickups (grant yen on take, don't go to inventory)
+# Currency pickups (grant currency on take, don't go to inventory)
 # Used by spawning pools, slot machines, NPC rewards, etc.
 # ----------------------------------------------------------------------------
 
@@ -267,17 +267,17 @@ Prototype: object
 Rarity: common
 Tags: currency slot_prize desk_drawer_loot foyer_vase_loot sitting_room_cushion_loot
 DescriptionShort: a few loose coins
-OnLook: A small handful of yen coins. Worth about ¥100.
-OnTake: {{ effects.grant_currency(100) }}{{ effects.destroy() }}{{ effects.broadcast("**" ~ user ~ "** pockets " ~ e ~ " (+¥100)") }}You pick up the {{ e.name }}. (+¥100)
+OnLook: A small handful of coins. Worth about ¤100.
+OnTake: {{ effects.grant_currency(100) }}{{ effects.destroy() }}{{ effects.broadcast("**" ~ user ~ "** pockets " ~ e ~ " (+¤100)") }}You pick up the {{ e.name }}. (+¤100)
 
 Id: bundle_of_bills
 Name: bundle of bills
 Prototype: object
 Rarity: uncommon
 Tags: currency slot_prize desk_drawer_loot foyer_vase_loot
-DescriptionShort: a bundle of yen notes
-OnLook: A bundle of yen notes held together with a paper band. Worth about ¥1,000.
-OnTake: {{ effects.grant_currency(1000) }}{{ effects.destroy() }}{{ effects.broadcast("**" ~ user ~ "** pockets " ~ e ~ " (+¥1,000)") }}You pick up the {{ e.name }}. (+¥1,000)
+DescriptionShort: a bundle of banknotes
+OnLook: A bundle of banknotes held together with a paper band. Worth about ¤1,000.
+OnTake: {{ effects.grant_currency(1000) }}{{ effects.destroy() }}{{ effects.broadcast("**" ~ user ~ "** pockets " ~ e ~ " (+¤1,000)") }}You pick up the {{ e.name }}. (+¤1,000)
 
 Id: money_clip
 Name: money clip
@@ -285,8 +285,8 @@ Prototype: object
 Rarity: rare
 Tags: currency slot_prize foyer_vase_loot
 DescriptionShort: a silver money clip stuffed with cash
-OnLook: An elegant silver money clip stuffed with neatly folded bills. Worth about ¥5,000.
-OnTake: {{ effects.grant_currency(5000) }}{{ effects.destroy() }}{{ effects.broadcast("**" ~ user ~ "** pockets " ~ e ~ " (+¥5,000)") }}You pick up the {{ e.name }}. (+¥5,000)
+OnLook: An elegant silver money clip stuffed with neatly folded bills. Worth about ¤5,000.
+OnTake: {{ effects.grant_currency(5000) }}{{ effects.destroy() }}{{ effects.broadcast("**" ~ user ~ "** pockets " ~ e ~ " (+¤5,000)") }}You pick up the {{ e.name }}. (+¤5,000)
 
 Id: cash_envelope
 Name: cash envelope
@@ -294,8 +294,8 @@ Prototype: object
 Rarity: epic
 Tags: currency slot_prize
 DescriptionShort: a thick cash envelope
-OnLook: A heavy envelope filled with a substantial stack of bills. Worth about ¥25,000.
-OnTake: {{ effects.grant_currency(25000) }}{{ effects.destroy() }}{{ effects.broadcast("**" ~ user ~ "** pockets " ~ e ~ " (+¥25,000)") }}You pick up the {{ e.name }}. (+¥25,000)
+OnLook: A heavy envelope filled with a substantial stack of bills. Worth about ¤25,000.
+OnTake: {{ effects.grant_currency(25000) }}{{ effects.destroy() }}{{ effects.broadcast("**" ~ user ~ "** pockets " ~ e ~ " (+¤25,000)") }}You pick up the {{ e.name }}. (+¤25,000)
 
 Id: briefcase_of_cash
 Name: briefcase of cash
@@ -303,8 +303,8 @@ Prototype: object
 Rarity: legendary
 Tags: currency slot_prize
 DescriptionShort: a briefcase filled with cash
-OnLook: A sleek black briefcase packed with neat stacks of bills. Worth about ¥100,000.
-OnTake: {{ effects.grant_currency(100000) }}{{ effects.destroy() }}{{ effects.broadcast("**" ~ user ~ "** pockets " ~ e ~ " (+¥100,000)") }}You pick up the {{ e.name }}. (+¥100,000)
+OnLook: A sleek black briefcase packed with neat stacks of bills. Worth about ¤100,000.
+OnTake: {{ effects.grant_currency(100000) }}{{ effects.destroy() }}{{ effects.broadcast("**" ~ user ~ "** pockets " ~ e ~ " (+¤100,000)") }}You pick up the {{ e.name }}. (+¤100,000)
 
 Id: gold_brick
 Name: gold brick
@@ -312,8 +312,8 @@ Prototype: object
 Rarity: mythic
 Tags: currency slot_prize
 DescriptionShort: a gleaming gold brick
-OnLook: A solid gold brick stamped with official mint markings. Worth about ¥500,000.
-OnTake: {{ effects.grant_currency(500000) }}{{ effects.destroy() }}{{ effects.broadcast("**" ~ user ~ "** pockets " ~ e ~ " (+¥500,000)") }}You pick up the {{ e.name }}. (+¥500,000)
+OnLook: A solid gold brick stamped with official mint markings. Worth about ¤500,000.
+OnTake: {{ effects.grant_currency(500000) }}{{ effects.destroy() }}{{ effects.broadcast("**" ~ user ~ "** pockets " ~ e ~ " (+¤500,000)") }}You pick up the {{ e.name }}. (+¤500,000)
 
 # ----------------------------------------------------------------------------
 # Generic items (used by spawning pools across multiple locations)
@@ -1075,9 +1075,9 @@ DescriptionLong: ```
 + Big update! We now have an economy.
 +
 + CURRENCY SYSTEM
-+ Every player starts with ¥1,000 and gets a wallet pinned in their
-+ inventory. Use /pay to send yen to other players in the same room.
-+ There's a house account with 1 billion yen that funds all the loot.
++ Every player starts with ¤1,000 and gets a wallet pinned in their
++ inventory. Use /pay to send money to other players in the same room.
++ There's a house account with 1 billion that funds all the loot.
 + Double-entry ledger for full auditability.
 +
 + SLOT MACHINE
@@ -1087,13 +1087,13 @@ DescriptionLong: ```
 + Avatar Blu-rays, and currency pickups.
 +
 + CURRENCY PICKUPS
-+ New item type that grants yen directly without clogging inventory:
-+ - loose_coins: ¥100 (common)
-+ - bundle_of_bills: ¥1,000 (uncommon)
-+ - money_clip: ¥5,000 (rare)
-+ - cash_envelope: ¥25,000 (epic)
-+ - briefcase_of_cash: ¥100,000 (legendary)
-+ - gold_brick: ¥500,000 (mythic)
++ New item type that grants currency directly without clogging inventory:
++ - loose_coins: ¤100 (common)
++ - bundle_of_bills: ¤1,000 (uncommon)
++ - money_clip: ¤5,000 (rare)
++ - cash_envelope: ¤25,000 (epic)
++ - briefcase_of_cash: ¤100,000 (legendary)
++ - gold_brick: ¤500,000 (mythic)
 +
 + GALLERY
 + The gallery now has a rotating wall of paintings that spawn from
@@ -1316,9 +1316,9 @@ Prototype: furniture
 Room: lounge
 ContentsVisible: no
 DescriptionShort: A vintage {{ e.name }} stands against the wall.
-DescriptionLong: A classic one-armed bandit with three spinning reels. The chrome handle gleams invitingly. __Pull__ the handle to try your luck! ¥5 per pull.
+DescriptionLong: A classic one-armed bandit with three spinning reels. The chrome handle gleams invitingly. __Pull__ the handle to try your luck! ¤5 per pull.
 OnTouch: The cold metal handle vibrates slightly.
-OnUse: {% if not e.contents %}The slot machine sits empty, waiting to be refilled.{% elif user.balance < 5 %}The slot machine costs ¥5 per pull. You only have {{ user.balance | money }}.{% else %}{{ effects.charge(5) }}{{ effects.dispense() }}{{ effects.broadcast("**" ~ user ~ "** puts ¥5 in the slot machine and pulls the lever...") }}You drop a ¥5 coin into the slot and pull the lever... The wheels spin... click click click...{% endif %}
+OnUse: {% if not e.contents %}The slot machine sits empty, waiting to be refilled.{% elif user.balance < 5 %}The slot machine costs ¤5 per pull. You only have {{ user.balance | money }}.{% else %}{{ effects.charge(5) }}{{ effects.dispense() }}{{ effects.broadcast("**" ~ user ~ "** puts ¤5 in the slot machine and pulls the lever...") }}You drop a ¤5 coin into the slot and pull the lever... The wheels spin... click click click...{% endif %}
 OnAttack: You kick the machine in frustration. It remains unmoved.
 
 # Slot machine prizes (spawned by lounge_slot_machine_pool)

--- a/data/worlds/test_world.rec
+++ b/data/worlds/test_world.rec
@@ -461,7 +461,7 @@ Rarity: common
 Tags: test_currency_spawn
 DescriptionShort: a pile of {{ e.name }}
 DescriptionLong: Test coins for currency grant testing.
-OnTake: {{ effects.grant_currency(100) }}{{ effects.destroy() }}{{ effects.broadcast("**" ~ user ~ "** pockets " ~ e ~ " (+¥100)") }}TEST_CURRENCY_RESPONSE - You pick up the coins. (+¥100)
+OnTake: {{ effects.grant_currency(100) }}{{ effects.destroy() }}{{ effects.broadcast("**" ~ user ~ "** pockets " ~ e ~ " (+¤100)") }}TEST_CURRENCY_RESPONSE - You pick up the coins. (+¤100)
 
 Id: test_dispenser
 Name: Test Dispenser
@@ -547,8 +547,8 @@ Prototype: furniture
 Room: store-room
 ContentsVisible: no
 DescriptionShort: A {{ e.name }} stands against the wall.
-DescriptionLong: A test machine that charges ¥5 per use and dispenses a prize.
-OnUse: {% if not e.contents %}The machine is empty.{% elif user.balance < 5 %}TEST_INSUFFICIENT_FUNDS - Not enough yen. You have {{ user.balance | money }}.{% else %}{{ effects.charge(5) }}{{ effects.dispense() }}{{ effects.broadcast("**" ~ user ~ "** uses the charge machine...") }}TEST_CHARGE_RESPONSE - You insert ¥5 and receive a prize!{% endif %}
+DescriptionLong: A test machine that charges ¤5 per use and dispenses a prize.
+OnUse: {% if not e.contents %}The machine is empty.{% elif user.balance < 5 %}TEST_INSUFFICIENT_FUNDS - Not enough money. You have {{ user.balance | money }}.{% else %}{{ effects.charge(5) }}{{ effects.dispense() }}{{ effects.broadcast("**" ~ user ~ "** uses the charge machine...") }}TEST_CHARGE_RESPONSE - You insert ¤5 and receive a prize!{% endif %}
 
 Id: test_charge_prize
 Name: Test Charge Prize

--- a/docs/adr/0005-currency-system.md
+++ b/docs/adr/0005-currency-system.md
@@ -19,9 +19,9 @@ Key requirements:
 
 ### Currency Choice
 
-In the context of **choosing an in-game currency**, facing **the need for a currency that fits the game's aesthetic and is easy to display**, we decided to **use Yen (¥)**, to achieve **a clean, recognizable symbol that works well with integer amounts**, accepting **that this is a stylistic choice without gameplay implications**.
+In the context of **choosing an in-game currency**, facing **the need for a currency that fits the game's aesthetic and is easy to display**, we decided to **use the generic currency sign (¤)**, to achieve **a clean, recognizable symbol that works well with integer amounts**, accepting **that this is a stylistic choice without gameplay implications**.
 
-**Starting Balance:** ¥1000 for all new players.
+**Starting Balance:** ¤1000 for all new players.
 
 ### Wallet as Inventory Item
 

--- a/migrations/014_currency_system.sql
+++ b/migrations/014_currency_system.sql
@@ -13,7 +13,7 @@ CREATE TABLE currency_accounts (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- House account with 1 billion yen
+-- House account with 1 billion
 INSERT INTO currency_accounts (user_id, balance)
 VALUES (0, 1000000000);
 

--- a/mudd/cogs/betting.py
+++ b/mudd/cogs/betting.py
@@ -77,7 +77,7 @@ class Betting(commands.Cog):
     )
     @app_commands.describe(
         horse="Horse to bet on",
-        amount="Amount to bet in yen (0 to cancel)",
+        amount="Amount to bet (0 to cancel)",
     )
     @app_commands.autocomplete(horse=horse_autocomplete)
     async def bet(
@@ -149,8 +149,8 @@ class Betting(commands.Cog):
 
             await interaction.response.send_message(
                 f"Cancelled your bet on **{result.horse_name}**. "
-                f"\u00a5{result.amount:,} refunded.\n"
-                f"Balance: \u00a5{result.new_balance:,}",
+                f"\u00a4{result.amount:,} refunded.\n"
+                f"Balance: \u00a4{result.new_balance:,}",
                 ephemeral=True,
             )
 
@@ -197,9 +197,9 @@ class Betting(commands.Cog):
             return
 
         await interaction.response.send_message(
-            f"Bet \u00a5{result.amount:,} on **{result.horse_name}** "
+            f"Bet \u00a4{result.amount:,} on **{result.horse_name}** "
             f"({result.displayed_payout:.1f}:1)\n"
-            f"Balance: \u00a5{result.new_balance:,}",
+            f"Balance: \u00a4{result.new_balance:,}",
             ephemeral=True,
         )
 
@@ -208,7 +208,7 @@ class Betting(commands.Cog):
             interaction.guild,
             race.id,
             f"**{interaction.user.display_name}** bet "
-            f"\u00a5{result.amount:,} on **{result.horse_name}**",
+            f"\u00a4{result.amount:,} on **{result.horse_name}**",
         )
 
         # Update wallet thread (best-effort, after response)
@@ -318,9 +318,9 @@ def _error_message(error: BetError | None) -> str:
         case BetError.HORSE_NOT_IN_RACE:
             return "That horse isn't in this race."
         case BetError.INSUFFICIENT_FUNDS:
-            return "You don't have enough yen."
+            return "You don't have enough money."
         case BetError.AMOUNT_TOO_LOW:
-            return f"Minimum bet is \u00a5{MIN_BET:,}."
+            return f"Minimum bet is \u00a4{MIN_BET:,}."
         case BetError.NO_BET_TO_CANCEL:
             return "You don't have a bet on that horse to cancel."
         case BetError.NO_CURRENCY_ACCOUNT:

--- a/mudd/cogs/economy.py
+++ b/mudd/cogs/economy.py
@@ -74,8 +74,8 @@ class Economy(commands.Cog):
             for p in matches[:25]
         ]
 
-    @app_commands.command(name="pay", description="Give yen to another player")
-    @app_commands.describe(recipient="Player to pay", amount="Amount in yen")
+    @app_commands.command(name="pay", description="Give currency to another player")
+    @app_commands.describe(recipient="Player to pay", amount="Amount to pay")
     @app_commands.rename(recipient="to")
     @app_commands.autocomplete(recipient=recipient_autocomplete)
     async def pay(
@@ -84,7 +84,7 @@ class Economy(commands.Cog):
         recipient: str,
         amount: int,
     ):
-        """Transfer yen to another player in the same room."""
+        """Transfer currency to another player in the same room."""
         if not interaction.guild:
             await interaction.response.send_message(
                 "This command must be used in a server.", ephemeral=True
@@ -171,7 +171,7 @@ class Economy(commands.Cog):
         if not result.success:
             match result.error:
                 case TransferError.INSUFFICIENT_FUNDS:
-                    msg = "You don't have enough yen."
+                    msg = "You don't have enough money."
                 case TransferError.NO_SENDER_ACCOUNT:
                     msg = (
                         "You don't have a currency account. Try looking at your wallet."
@@ -185,8 +185,8 @@ class Economy(commands.Cog):
             return
 
         # Format balances for display
-        sender_balance_str = f"\u00a5{result.sender_balance:,}"
-        amount_str = f"\u00a5{amount:,}"
+        sender_balance_str = f"\u00a4{result.sender_balance:,}"
+        amount_str = f"\u00a4{amount:,}"
 
         # Respond with confirmation
         await interaction.response.send_message(

--- a/mudd/cogs/racing.py
+++ b/mudd/cogs/racing.py
@@ -489,7 +489,7 @@ def _build_message_queue(
             message_type=MessageType.THREAD,
             content=(
                 "## Place your bets!\n"
-                f"• minimum bet is **¥{MIN_BET}**\n"
+                f"• minimum bet is **¤{MIN_BET}**\n"
                 "• `/bet <horse> <amount>` to place a bet\n"
                 "• `/bet <horse> 0` to cancel a bet\n"
                 "• You can bet on multiple horses\n"

--- a/mudd/events/collector.py
+++ b/mudd/events/collector.py
@@ -111,7 +111,7 @@ class EffectsCollector:
         """Queue granting currency to the user.
 
         Args:
-            amount: Amount of yen to grant (from house account)
+            amount: Amount to grant (from house account)
 
         Returns:
             Empty string (allows inline use in templates)
@@ -124,7 +124,7 @@ class EffectsCollector:
         """Queue a currency charge (debit) from the user.
 
         Args:
-            amount: Amount of yen to charge (debited to house account)
+            amount: Amount to charge (debited to house account)
 
         Returns:
             Empty string (allows inline use in templates)

--- a/mudd/models/user.py
+++ b/mudd/models/user.py
@@ -394,7 +394,7 @@ class User:
         """Get the user's currency balance.
 
         Returns:
-            Balance in yen (0 if no account exists)
+            Balance (0 if no account exists)
         """
         row = await self._pool.fetchrow(
             "SELECT balance FROM currency_accounts WHERE user_id = $1",
@@ -746,7 +746,7 @@ class User:
             )
 
         # Broadcast the payment to the channel
-        amount_str = f"\u00a5{amount:,}"
+        amount_str = f"\u00a4{amount:,}"
         broadcast_msg = f"{self.mention} paid {amount_str} to {recipient.mention}"
         for observer in self._observers:
             observer.notify(BroadcastEvent(message=broadcast_msg))

--- a/mudd/observers/inventory.py
+++ b/mudd/observers/inventory.py
@@ -39,7 +39,7 @@ def _format_transaction_message(event: BalanceChangedEvent) -> str:
     sign = "+" if event.delta >= 0 else "-"
     abs_amount = abs(event.delta)
     balance = event.new_balance
-    return f"{sign}\u00a5{abs_amount:,} | {event.memo} | Balance: \u00a5{balance:,}"
+    return f"{sign}\u00a4{abs_amount:,} | {event.memo} | Balance: \u00a4{balance:,}"
 
 
 class InventoryReconciler:

--- a/mudd/racing/betting.py
+++ b/mudd/racing/betting.py
@@ -22,15 +22,15 @@ def format_payout_message(payouts: list[PayoutRecord]) -> str:
         lines.append("Winners:")
         for p in winners:
             lines.append(
-                f"\U0001f4b9 <@{p.user_id}> bet \u00a5{p.amount_bet:,} on "
-                f"**{p.horse_name}** and won **\u00a5{p.payout:,}**!"
+                f"\U0001f4b9 <@{p.user_id}> bet \u00a4{p.amount_bet:,} on "
+                f"**{p.horse_name}** and won **\u00a4{p.payout:,}**!"
             )
 
     if losers:
         lines.append("Losers:")
         for p in losers:
             lines.append(
-                f"\U0001f53b <@{p.user_id}> bet \u00a5{p.amount_bet:,} on "
+                f"\U0001f53b <@{p.user_id}> bet \u00a4{p.amount_bet:,} on "
                 f"**{p.horse_name}** and lost."
             )
 

--- a/mudd/racing/betting_unit_test.py
+++ b/mudd/racing/betting_unit_test.py
@@ -23,8 +23,8 @@ def test_format_payout_message_winner_only() -> None:
     assert "### Betting Results" in result
     assert "<@123>" in result
     assert "Flash" in result
-    assert "¥100" in result
-    assert "¥350" in result
+    assert "¤100" in result
+    assert "¤350" in result
 
 
 def test_format_payout_message_loser_only() -> None:
@@ -85,5 +85,5 @@ def test_format_payout_message_large_amounts() -> None:
         ),
     ]
     result = format_payout_message(payouts)
-    assert "¥1,000" in result
-    assert "¥5,500" in result
+    assert "¤1,000" in result
+    assert "¤5,500" in result

--- a/mudd/template.py
+++ b/mudd/template.py
@@ -18,8 +18,8 @@ class TemplateRenderError(Exception):
 
 
 def _money_filter(value: int) -> str:
-    """Format an integer as a yen currency string."""
-    return f"¥{value:,}"
+    """Format an integer as a currency string."""
+    return f"¤{value:,}"
 
 
 def _md_list_filter(items: list[object]) -> str:

--- a/tests/integration/test_scenarios.py
+++ b/tests/integration/test_scenarios.py
@@ -415,7 +415,7 @@ async def test_payment_broadcast_and_mentions(test_db, clean_user_state):
     # Check that BroadcastEvent was emitted
     broadcast_events = [e for e in reconciler.events if isinstance(e, BroadcastEvent)]
     assert len(broadcast_events) == 1
-    assert broadcast_events[0].message == "<@3001> paid ¥50 to <@3002>"
+    assert broadcast_events[0].message == "<@3001> paid ¤50 to <@3002>"
 
     # Check that BalanceChangedEvents use mentions in memos
     balance_events = [
@@ -616,7 +616,7 @@ async def test_wallet_balance_display(test_db, clean_user_state):
     result = await act(
         test_db, user.id, LookCommand(), f"entity://{wallet.instance_id}"
     )
-    assert "¥1,000" in result.output
+    assert "¤1,000" in result.output
 
 
 async def test_transfer_insufficient_funds(test_db, clean_user_state):
@@ -928,8 +928,8 @@ async def test_cannot_drop_item_not_in_inventory(test_db, clean_user_state):
     )
 
 
-async def test_charge_machine_deducts_yen_and_dispenses(test_db, clean_user_state):
-    """Charge machine deducts ¥5, dispenses prize, emits balance event."""
+async def test_charge_machine_deducts_currency_and_dispenses(test_db, clean_user_state):
+    """Charge machine deducts ¤5, dispenses prize, emits balance event."""
     user = await create_test_user(test_db, room_id="store-room")
     await User.create_currency_account(test_db, user.id, 100)
 
@@ -976,9 +976,9 @@ async def test_charge_machine_deducts_yen_and_dispenses(test_db, clean_user_stat
 
 
 async def test_charge_machine_insufficient_funds(test_db, clean_user_state):
-    """Player with insufficient yen sees rejection message, no charge or dispense."""
+    """Player with insufficient funds sees rejection message, no charge or dispense."""
     user = await create_test_user(test_db, room_id="store-room")
-    await User.create_currency_account(test_db, user.id, 3)  # Less than ¥5
+    await User.create_currency_account(test_db, user.id, 3)  # Less than ¤5
 
     # Use the charge machine
     machine = next(
@@ -992,7 +992,7 @@ async def test_charge_machine_insufficient_funds(test_db, clean_user_state):
 
     # Template rendered the insufficient funds path
     assert "TEST_INSUFFICIENT_FUNDS" in result.output
-    assert "¥3" in result.output
+    assert "¤3" in result.output
 
     # No charge or dispense signals were emitted
     assert len(result.effects.currency_charges) == 0


### PR DESCRIPTION
## Summary

- Replace all `¥` / `\u00a5` (yen) references with `¤` / `\u00a4` (generic currency sign) across 17 files
- Update user-facing strings: "yen" → neutral terms like "currency", "money"
- Update world data (mansion.rec, test_world.rec) entity descriptions and templates
- Update docs (DESIGN.md, README.md, ADR) and migration comments
- Update test assertions to match new symbol

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] All 341 tests pass
- [x] Grep confirms no remaining `¥`, `\u00a5`, or `yen` references in source/data/test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)